### PR TITLE
Fix 'fmt' make task to use four spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ examples: */**.go
 	done
 
 fmt: */**.go
-	go fmt ./...
+	gofmt -w -l -tabs=false -tabwidth=4 */**.go *.go
 
 test: */**.go
 	go test ./...


### PR DESCRIPTION
Since this project apparently uses four spaces instead of tabs, the Makefile should be updated to reflect this.

As a side note: Why not go with the Go conventions and use tabs?
