### PR TITLE
add a new client creation function to allow custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ import (
 
 func main() {
     client := pusher.NewClient("appId", "key", "secret", false)
+    // in the case of your need to use custom server endpoint
+    //client := pusher.NewCustomClient("appId", "key", "secret", "localhost:8080", "http")
 
     done := make(chan bool)
 

--- a/client.go
+++ b/client.go
@@ -71,6 +71,16 @@ func NewClient(appid, key, secret string) *Client {
 	}
 }
 
+func NewCustomClient(appid, key, secret, host, scheme string) *Client {
+	return &Client{
+		appid:  appid,
+		key:    key,
+		secret: secret,
+		Host:   host,
+		Scheme: scheme,
+	}
+}
+
 func (c *Client) Publish(data, event string, channels ...string) error {
 	timestamp := c.stringTimestamp()
 


### PR DESCRIPTION
Useful if you need to use custom pusher server (internal usage for example)
